### PR TITLE
Add array support

### DIFF
--- a/PgBulkInsert/src/main/de/bytefish/pgbulkinsert/PgBulkInsert.java
+++ b/PgBulkInsert/src/main/de/bytefish/pgbulkinsert/PgBulkInsert.java
@@ -9,6 +9,7 @@ import de.bytefish.pgbulkinsert.de.bytefish.pgbulkinsert.functional.Func2;
 import de.bytefish.pgbulkinsert.de.bytefish.pgbulkinsert.pgsql.PgBinaryWriter;
 import de.bytefish.pgbulkinsert.de.bytefish.pgbulkinsert.pgsql.handlers.IValueHandler;
 import de.bytefish.pgbulkinsert.de.bytefish.pgbulkinsert.pgsql.handlers.IValueHandlerProvider;
+import de.bytefish.pgbulkinsert.de.bytefish.pgbulkinsert.pgsql.handlers.ListValueHandler;
 import de.bytefish.pgbulkinsert.de.bytefish.pgbulkinsert.pgsql.handlers.ValueHandlerProvider;
 import de.bytefish.pgbulkinsert.de.bytefish.pgbulkinsert.util.StringUtils;
 
@@ -145,6 +146,16 @@ public abstract class PgBulkInsert<TEntity> {
 
         addColumn(columnName, (binaryWriter, entity) -> {
             binaryWriter.write(valueHandler, propertyGetter.invoke(entity));
+        });
+    }
+
+    protected <TElement> void mapList(String columnName, Class<TElement> elementType, int nDims, int elementOid, Func2<TEntity, List<TElement>> propertyGetter)
+    {
+        final IValueHandler<TElement> valueHandler = provider.resolve(elementType);
+        final ListValueHandler<TElement> listHandler = new ListValueHandler<>(nDims, elementOid, valueHandler);
+
+        addColumn(columnName, (binaryWriter, entity) -> {
+            binaryWriter.write(listHandler, propertyGetter.invoke(entity));
         });
     }
 

--- a/PgBulkInsert/src/main/de/bytefish/pgbulkinsert/pgsql/handlers/ListValueHandler.java
+++ b/PgBulkInsert/src/main/de/bytefish/pgbulkinsert/pgsql/handlers/ListValueHandler.java
@@ -1,0 +1,60 @@
+package de.bytefish.pgbulkinsert.de.bytefish.pgbulkinsert.pgsql.handlers;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.lang.reflect.Type;
+import java.util.List;
+
+public class ListValueHandler<TElement> extends BaseValueHandler<List<TElement>> {
+    private int nDims;
+    private int elementOid;
+    private IValueHandler valueHandler;
+
+    public ListValueHandler(int nDims, int elementOid, IValueHandler valueHandler) {
+        this.nDims = nDims;
+        this.elementOid = elementOid;
+        this.valueHandler = valueHandler;
+    }
+
+    @Override
+    protected void internalHandle(DataOutputStream buffer, final List<TElement> value) throws Exception {
+        ByteArrayOutputStream byteArrayOutput = new ByteArrayOutputStream();
+        DataOutputStream arrayOutput = new DataOutputStream(byteArrayOutput);
+
+        arrayOutput.writeInt(nDims);
+        arrayOutput.writeInt(0); // TODO flags?
+        arrayOutput.writeInt(elementOid);
+
+        List<?> currentDim = value;
+        for (int dimI = 0; dimI < nDims; dimI++) {
+            arrayOutput.writeInt(currentDim.size());
+            arrayOutput.writeInt(1); // lower bound
+
+            if (dimI < nDims - 1) {
+                currentDim = (List<?>)currentDim.get(0);
+            }
+        }
+
+        writeArray(arrayOutput, value, nDims - 1);
+
+        buffer.writeInt(byteArrayOutput.size());
+        buffer.write(byteArrayOutput.toByteArray());
+    }
+
+    private void writeArray(DataOutputStream buffer, final List<?> values, int remainingDims) throws Exception {
+        if (remainingDims > 0) {
+            for (List<?> subList: (List<List<?>>)values) {
+                writeArray(buffer, subList, remainingDims - 1);
+            }
+        } else {
+            for (TElement value: (List<TElement>)values) {
+                valueHandler.handle(buffer, value);
+            }
+        }
+    }
+
+    @Override
+    public Type getTargetType() {
+        return List.class;
+    }
+}

--- a/PgBulkInsert/src/test/de/bytefish/pgbulkinsert/de/bytefish/pgbulkinsert/IntegrationTest.java
+++ b/PgBulkInsert/src/test/de/bytefish/pgbulkinsert/de/bytefish/pgbulkinsert/IntegrationTest.java
@@ -24,6 +24,8 @@ public class IntegrationTest extends TransactionalTestBase {
 
         private LocalDate birthDate;
 
+        private ArrayList<Integer> luckyNumbers;
+
         public Person() {}
 
         public String getFirstName() {
@@ -50,6 +52,9 @@ public class IntegrationTest extends TransactionalTestBase {
             this.birthDate = birthDate;
         }
 
+        public List<Integer> getLuckyNumbers() { return luckyNumbers; }
+
+        public void setLuckyNumbers(ArrayList<Integer> luckyNumbers) { this.luckyNumbers = luckyNumbers; }
     }
 
     public class PersonBulkInserter extends PgBulkInsert<Person>
@@ -60,6 +65,7 @@ public class IntegrationTest extends TransactionalTestBase {
             mapString("first_name", Person::getFirstName);
             mapString("last_name", Person::getLastName);
             mapDate("birth_date", Person::getBirthDate);
+            mapList("lucky_numbers", Integer.class, 1, 23, Person::getLuckyNumbers);
         }
     }
 
@@ -86,9 +92,15 @@ public class IntegrationTest extends TransactionalTestBase {
         for (int pos = 0; pos < numPersons; pos++) {
             Person p = new Person();
 
+            ArrayList<Integer> luckyNumbers = new ArrayList<>();
+            luckyNumbers.add(11);
+            luckyNumbers.add(0);
+            luckyNumbers.add(-8);
+
             p.setFirstName("Philipp");
             p.setLastName("Wagner");
             p.setBirthDate(LocalDate.of(1986, 5, 12));
+            p.setLuckyNumbers(luckyNumbers);
 
             persons.add(p);
         }
@@ -102,7 +114,8 @@ public class IntegrationTest extends TransactionalTestBase {
                 "            (\n" +
                 "                first_name text,\n" +
                 "                last_name text,\n" +
-                "                birth_date date\n" +
+                "                birth_date date,\n" +
+                "                lucky_numbers int[]\n" +
                 "            );";
 
         Statement statement = connection.createStatement();


### PR DESCRIPTION
The good news: this patch works for me and lets me export arrays in binary format!

The bad news: the API for using it is a little bit yucky.  Specifically, `mapList` requires you to pass in the number of array dimensions (which is not so awful, IMO) and the OID of the element type you're importing (ugh).

I thought of automatically attempting to load the OID from the database, but that seems perhaps too intrusive.  I'd certainly welcome suggestions on how to improve it, or if you feel like it's useful enough to release as is, then we can certainly improve it later as well.