### PR TITLE
Expose some private methods as public

### DIFF
--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/PgBulkInsert.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/PgBulkInsert.java
@@ -67,7 +67,7 @@ public abstract class PgBulkInsert<TEntity> implements IPgBulkInsert<TEntity> {
         }
     }
 
-    private void saveEntity(PgBinaryWriter bw, TEntity entity) throws SaveEntityFailedException {
+    public void saveEntity(PgBinaryWriter bw, TEntity entity) throws SaveEntityFailedException {
         synchronized (bw) {
             // Start a New Row:
             bw.startRow(columns.size());
@@ -269,7 +269,7 @@ public abstract class PgBulkInsert<TEntity> implements IPgBulkInsert<TEntity> {
         return this;
     }
 
-    private String getCopyCommand()
+    public String getCopyCommand()
     {
         String commaSeparatedColumns = columns.stream()
                 .map(x -> x.getColumnName())


### PR DESCRIPTION
Many APIs only give you access to one entity at a time, even if there is some kind of stream backing it (e.g., JDBC, Kafka).

So, I was hoping to inline and modify the `PgBulkInsert::saveAll()` method and call the following directly:

```java
        CopyManager cpManager = connection.getCopyAPI();
        CopyIn copyIn = cpManager.copyIn(getCopyCommand());

        try (PgBinaryWriter bw = new PgBinaryWriter()) {

            // Wrap the CopyOutputStream in our own Writer:
            bw.open(new PGCopyOutputStream(copyIn));

            // Insert Each Column:
            entities.forEach(entity -> this.saveEntity(bw, entity));
        }
```

However, two methods are private and can't be called directly.

Exposing them would allow users to control the opening and closing of a `PgBinaryWriter`, allowing usage with other APIs that provide messages one-by-one.