### PR TITLE
ByteArrayValueHandler should accept primitive byte array. Usage java functional interfaces

### DIFF
--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/PgBulkInsert.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/PgBulkInsert.java
@@ -14,6 +14,7 @@ import org.postgresql.copy.CopyManager;
 import org.postgresql.copy.PGCopyOutputStream;
 
 import java.sql.SQLException;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 public class PgBulkInsert<TEntity> implements IPgBulkInsert<TEntity> {
@@ -21,19 +22,14 @@ public class PgBulkInsert<TEntity> implements IPgBulkInsert<TEntity> {
     private final IConfiguration configuration;
     private final AbstractMapping<TEntity> mapping;
 
-    public PgBulkInsert(AbstractMapping mapping) {
+    public PgBulkInsert(AbstractMapping<TEntity> mapping) {
         this(new Configuration(), mapping);
     }
 
-    public PgBulkInsert(IConfiguration configuration, AbstractMapping mapping)
+    public PgBulkInsert(IConfiguration configuration, AbstractMapping<TEntity> mapping)
     {
-        if(configuration == null) {
-            throw new IllegalArgumentException("configuration");
-        }
-
-        if(mapping == null) {
-            throw new IllegalArgumentException("mapping");
-        }
+        Objects.requireNonNull(configuration, "'configuration' has to be set");
+        Objects.requireNonNull(mapping, "'mapping' has to be set");
 
         this.configuration = configuration;
         this.mapping = mapping;
@@ -62,7 +58,7 @@ public class PgBulkInsert<TEntity> implements IPgBulkInsert<TEntity> {
             // Iterate over each column mapping:
             mapping.getColumns().forEach(column -> {
                 try {
-                    column.getWrite().invoke(bw, entity);
+                    column.getWrite().accept(bw, entity);
                 } catch (Exception e) {
                     throw new SaveEntityFailedException(e);
                 }

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/functional/Action0.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/functional/Action0.java
@@ -1,9 +1,0 @@
-// Copyright (c) Philipp Wagner. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-package de.bytefish.pgbulkinsert.functional;
-
-@FunctionalInterface
-public interface Action0 {
-    void invoke() throws Exception;
-}

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/functional/Action1.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/functional/Action1.java
@@ -1,9 +1,0 @@
-// Copyright (c) Philipp Wagner. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-package de.bytefish.pgbulkinsert.functional;
-
-@FunctionalInterface
-public interface Action1<S> {
-    void invoke(S s) throws Exception;
-}

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/functional/Action2.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/functional/Action2.java
@@ -1,9 +1,0 @@
-// Copyright (c) Philipp Wagner. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-package de.bytefish.pgbulkinsert.functional;
-
-@FunctionalInterface
-public interface Action2<S, T> {
-    void invoke(S s, T t) throws Exception;
-}

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/functional/Func1.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/functional/Func1.java
@@ -1,9 +1,0 @@
-// Copyright (c) Philipp Wagner. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-package de.bytefish.pgbulkinsert.functional;
-
-@FunctionalInterface
-public interface Func1<S> {
-    S invoke() throws Exception;
-}

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/functional/Func2.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/functional/Func2.java
@@ -1,9 +1,0 @@
-// Copyright (c) Philipp Wagner. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-package de.bytefish.pgbulkinsert.functional;
-
-@FunctionalInterface
-public interface Func2<S, T> {
-    T invoke(S s);
-}

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/mapping/AbstractMapping.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/mapping/AbstractMapping.java
@@ -3,8 +3,6 @@
 
 package de.bytefish.pgbulkinsert.mapping;
 
-import de.bytefish.pgbulkinsert.functional.Action2;
-import de.bytefish.pgbulkinsert.functional.Func2;
 import de.bytefish.pgbulkinsert.model.ColumnDefinition;
 import de.bytefish.pgbulkinsert.model.TableDefinition;
 import de.bytefish.pgbulkinsert.pgsql.PgBinaryWriter;
@@ -22,6 +20,8 @@ import java.net.Inet6Address;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public abstract class AbstractMapping<TEntity> {
@@ -43,7 +43,7 @@ public abstract class AbstractMapping<TEntity> {
     }
 
 
-    protected <TElementType, TCollectionType extends Collection<TElementType>> void mapCollection(String columnName, DataType dataType, Func2<TEntity, TCollectionType> propertyGetter) {
+    protected <TElementType, TCollectionType extends Collection<TElementType>> void mapCollection(String columnName, DataType dataType, Function<TEntity, TCollectionType> propertyGetter) {
 
         final IValueHandler<TElementType> valueHandler = provider.resolve(dataType);
         final int valueOID = ObjectIdentifier.mapFrom(dataType);
@@ -51,172 +51,172 @@ public abstract class AbstractMapping<TEntity> {
         map(columnName, new CollectionValueHandler<>(valueOID, valueHandler), propertyGetter);
     }
 
-    protected <TProperty> void map(String columnName, DataType dataType, Func2<TEntity, TProperty> propertyGetter) {
+    protected <TProperty> void map(String columnName, DataType dataType, Function<TEntity, TProperty> propertyGetter) {
         final IValueHandler<TProperty> valueHandler = provider.resolve(dataType);
 
         map(columnName, valueHandler, propertyGetter);
     }
 
-    protected <TProperty> void map(String columnName, IValueHandler<TProperty> valueHandler, Func2<TEntity, TProperty> propertyGetter) {
+    protected <TProperty> void map(String columnName, IValueHandler<TProperty> valueHandler, Function<TEntity, TProperty> propertyGetter) {
         addColumn(columnName, (binaryWriter, entity) -> {
-            binaryWriter.write(valueHandler, propertyGetter.invoke(entity));
+            binaryWriter.write(valueHandler, propertyGetter.apply(entity));
         });
     }
 
-    protected void mapBoolean(String columnName, Func2<TEntity, Boolean> propertyGetter) {
+    protected void mapBoolean(String columnName, Function<TEntity, Boolean> propertyGetter) {
         map(columnName, DataType.Boolean, propertyGetter);
     }
 
-    protected void mapByte(String columnName, Func2<TEntity, Number> propertyGetter) {
+    protected void mapByte(String columnName, Function<TEntity, Number> propertyGetter) {
         map(columnName, DataType.Char, propertyGetter);
     }
 
-    protected void mapShort(String columnName, Func2<TEntity, Number> propertyGetter) {
+    protected void mapShort(String columnName, Function<TEntity, Number> propertyGetter) {
 
         map(columnName, DataType.Int2, propertyGetter);
     }
 
-    protected void mapInteger(String columnName, Func2<TEntity, Number> propertyGetter) {
+    protected void mapInteger(String columnName, Function<TEntity, Number> propertyGetter) {
         map(columnName, DataType.Int4, propertyGetter);
     }
 
-    protected void mapNumeric(String columnName, Func2<TEntity, Number> propertyGetter) {
+    protected void mapNumeric(String columnName, Function<TEntity, Number> propertyGetter) {
         map(columnName, DataType.Numeric, propertyGetter);
     }
 
-    protected void mapLong(String columnName, Func2<TEntity, Number> propertyGetter) {
+    protected void mapLong(String columnName, Function<TEntity, Number> propertyGetter) {
         map(columnName, DataType.Int8, propertyGetter);
     }
 
-    protected void mapFloat(String columnName, Func2<TEntity, Number> propertyGetter) {
+    protected void mapFloat(String columnName, Function<TEntity, Number> propertyGetter) {
         map(columnName, DataType.SinglePrecision, propertyGetter);
     }
 
-    protected void mapDouble(String columnName, Func2<TEntity, Number> propertyGetter) {
+    protected void mapDouble(String columnName, Function<TEntity, Number> propertyGetter) {
         map(columnName, DataType.DoublePrecision, propertyGetter);
     }
 
-    protected void mapDate(String columnName, Func2<TEntity, LocalDate> propertyGetter) {
+    protected void mapDate(String columnName, Function<TEntity, LocalDate> propertyGetter) {
         map(columnName, DataType.Date, propertyGetter);
     }
 
-    protected void mapInet4Addr(String columnName, Func2<TEntity, Inet4Address> propertyGetter) {
+    protected void mapInet4Addr(String columnName, Function<TEntity, Inet4Address> propertyGetter) {
         map(columnName, DataType.Inet4, propertyGetter);
     }
 
-    protected void mapInet6Addr(String columnName, Func2<TEntity, Inet6Address> propertyGetter) {
+    protected void mapInet6Addr(String columnName, Function<TEntity, Inet6Address> propertyGetter) {
         map(columnName, DataType.Inet6, propertyGetter);
     }
 
-    protected void mapTimeStamp(String columnName, Func2<TEntity, LocalDateTime> propertyGetter) {
+    protected void mapTimeStamp(String columnName, Function<TEntity, LocalDateTime> propertyGetter) {
         map(columnName, DataType.Timestamp, propertyGetter);
     }
 
-    protected void mapText(String columnName, Func2<TEntity, String> propertyGetter) {
+    protected void mapText(String columnName, Function<TEntity, String> propertyGetter) {
         map(columnName, DataType.Text, propertyGetter);
     }
 
-    protected void mapVarChar(String columnName, Func2<TEntity, String> propertyGetter) {
+    protected void mapVarChar(String columnName, Function<TEntity, String> propertyGetter) {
         map(columnName, DataType.Text, propertyGetter);
     }
 
-    protected void mapUUID(String columnName, Func2<TEntity, UUID> propertyGetter) {
+    protected void mapUUID(String columnName, Function<TEntity, UUID> propertyGetter) {
         map(columnName, DataType.Uuid, propertyGetter);
     }
 
-    protected void mapByteArray(String columnName, Func2<TEntity, Byte[]> propertyGetter) {
+    protected void mapByteArray(String columnName, Function<TEntity, Byte[]> propertyGetter) {
         map(columnName, DataType.Bytea, propertyGetter);
     }
 
-    protected void mapJsonb(String columnName, Func2<TEntity, String> propertyGetter) {
+    protected void mapJsonb(String columnName, Function<TEntity, String> propertyGetter) {
         map(columnName, DataType.Jsonb, propertyGetter);
     }
 
-    protected void mapHstore(String columnName, Func2<TEntity, Map<String, String>> propertyGetter) {
+    protected void mapHstore(String columnName, Function<TEntity, Map<String, String>> propertyGetter) {
         map(columnName, DataType.Hstore, propertyGetter);
     }
 
-    protected void mapPoint(String columnName, Func2<TEntity, Point> propertyGetter) {
+    protected void mapPoint(String columnName, Function<TEntity, Point> propertyGetter) {
         map(columnName, DataType.Point, propertyGetter);
     }
 
-    protected void mapBox(String columnName, Func2<TEntity, Box> propertyGetter) {
+    protected void mapBox(String columnName, Function<TEntity, Box> propertyGetter) {
         map(columnName, DataType.Box, propertyGetter);
     }
 
-    protected void mapPath(String columnName, Func2<TEntity, Path> propertyGetter) {
+    protected void mapPath(String columnName, Function<TEntity, Path> propertyGetter) {
         map(columnName, DataType.Path, propertyGetter);
     }
 
-    protected void mapPolygon(String columnName, Func2<TEntity, Polygon> propertyGetter) {
+    protected void mapPolygon(String columnName, Function<TEntity, Polygon> propertyGetter) {
         map(columnName, DataType.Polygon, propertyGetter);
     }
 
-    protected void mapLine(String columnName, Func2<TEntity, Line> propertyGetter) {
+    protected void mapLine(String columnName, Function<TEntity, Line> propertyGetter) {
         map(columnName, DataType.Line, propertyGetter);
     }
 
-    protected void mapLineSegment(String columnName, Func2<TEntity, LineSegment> propertyGetter) {
+    protected void mapLineSegment(String columnName, Function<TEntity, LineSegment> propertyGetter) {
         map(columnName, DataType.LineSegment, propertyGetter);
     }
 
-    protected void mapCircle(String columnName, Func2<TEntity, Circle> propertyGetter) {
+    protected void mapCircle(String columnName, Function<TEntity, Circle> propertyGetter) {
         map(columnName, DataType.Circle, propertyGetter);
     }
 
-    protected void mapMacAddress(String columnName, Func2<TEntity, MacAddress> propertyGetter) {
+    protected void mapMacAddress(String columnName, Function<TEntity, MacAddress> propertyGetter) {
         map(columnName, DataType.MacAddress, propertyGetter);
     }
 
-    protected void mapBooleanArray(String columnName, Func2<TEntity, Collection<Boolean>> propertyGetter) {
+    protected void mapBooleanArray(String columnName, Function<TEntity, Collection<Boolean>> propertyGetter) {
         mapCollection(columnName, DataType.Boolean, propertyGetter);
     }
 
-    protected <T extends Number> void mapShortArray(String columnName, Func2<TEntity, Collection<T>> propertyGetter) {
+    protected <T extends Number> void mapShortArray(String columnName, Function<TEntity, Collection<T>> propertyGetter) {
         mapCollection(columnName, DataType.Int2, propertyGetter);
     }
 
-    protected <T extends Number> void mapIntegerArray(String columnName, Func2<TEntity, Collection<T>> propertyGetter) {
+    protected <T extends Number> void mapIntegerArray(String columnName, Function<TEntity, Collection<T>> propertyGetter) {
         mapCollection(columnName, DataType.Int4, propertyGetter);
     }
 
-    protected <T extends Number> void mapLongArray(String columnName, Func2<TEntity, Collection<T>> propertyGetter) {
+    protected <T extends Number> void mapLongArray(String columnName, Function<TEntity, Collection<T>> propertyGetter) {
         mapCollection(columnName, DataType.Int8, propertyGetter);
     }
 
-    protected void mapTextArray(String columnName, Func2<TEntity, Collection<String>> propertyGetter) {
+    protected void mapTextArray(String columnName, Function<TEntity, Collection<String>> propertyGetter) {
         mapCollection(columnName, DataType.Text, propertyGetter);
     }
 
-    protected void mapVarCharArray(String columnName, Func2<TEntity, Collection<String>> propertyGetter) {
+    protected void mapVarCharArray(String columnName, Function<TEntity, Collection<String>> propertyGetter) {
         mapCollection(columnName, DataType.VarChar, propertyGetter);
     }
 
-    protected <T extends Number> void mapFloatArray(String columnName, Func2<TEntity, Collection<T>> propertyGetter) {
+    protected <T extends Number> void mapFloatArray(String columnName, Function<TEntity, Collection<T>> propertyGetter) {
         mapCollection(columnName, DataType.SinglePrecision, propertyGetter);
     }
 
-    protected <T extends Number> void mapDoubleArray(String columnName, Func2<TEntity, Collection<T>> propertyGetter) {
+    protected <T extends Number> void mapDoubleArray(String columnName, Function<TEntity, Collection<T>> propertyGetter) {
         mapCollection(columnName, DataType.DoublePrecision, propertyGetter);
     }
 
-    protected <T extends Number> void mapNumericArray(String columnName, Func2<TEntity, Collection<T>> propertyGetter) {
+    protected <T extends Number> void mapNumericArray(String columnName, Function<TEntity, Collection<T>> propertyGetter) {
         mapCollection(columnName, DataType.Numeric, propertyGetter);
     }
 
-    protected void mapUUIDArray(String columnName, Func2<TEntity, Collection<UUID>> propertyGetter) {
+    protected void mapUUIDArray(String columnName, Function<TEntity, Collection<UUID>> propertyGetter) {
         mapCollection(columnName, DataType.Uuid, propertyGetter);
     }
 
-    protected void mapInet4Array(String columnName, Func2<TEntity, Collection<Inet4Address>> propertyGetter) {
+    protected void mapInet4Array(String columnName, Function<TEntity, Collection<Inet4Address>> propertyGetter) {
         mapCollection(columnName, DataType.Inet4, propertyGetter);
     }
 
-    protected void mapInet6Array(String columnName, Func2<TEntity, Collection<Inet6Address>> propertyGetter) {
+    protected void mapInet6Array(String columnName, Function<TEntity, Collection<Inet6Address>> propertyGetter) {
         mapCollection(columnName, DataType.Inet6, propertyGetter);
     }
 
-    private void addColumn(String columnName, Action2<PgBinaryWriter, TEntity> action) {
+    private void addColumn(String columnName, BiConsumer<PgBinaryWriter, TEntity> action) {
         columns.add(new ColumnDefinition(columnName, action));
     }
 

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/model/ColumnDefinition.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/model/ColumnDefinition.java
@@ -3,16 +3,17 @@
 
 package de.bytefish.pgbulkinsert.model;
 
-import de.bytefish.pgbulkinsert.functional.Action2;
+import java.util.function.BiConsumer;
+
 import de.bytefish.pgbulkinsert.pgsql.PgBinaryWriter;
 
 public class ColumnDefinition<TEntity>
 {
     private final String columnName;
 
-    private final Action2<PgBinaryWriter, TEntity> write;
+    private final BiConsumer<PgBinaryWriter, TEntity> write;
 
-    public ColumnDefinition(String columnName, Action2<PgBinaryWriter, TEntity> write) {
+    public ColumnDefinition(String columnName, BiConsumer<PgBinaryWriter, TEntity> write) {
         this.columnName = columnName;
         this.write = write;
     }
@@ -21,7 +22,7 @@ public class ColumnDefinition<TEntity>
         return columnName;
     }
 
-    public Action2<PgBinaryWriter, TEntity> getWrite() {
+    public BiConsumer<PgBinaryWriter, TEntity> getWrite() {
         return write;
     }
 

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/ByteArrayValueHandler.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/ByteArrayValueHandler.java
@@ -5,12 +5,12 @@ package de.bytefish.pgbulkinsert.pgsql.handlers;
 
 import java.io.DataOutputStream;
 
-public class ByteArrayValueHandler extends BaseValueHandler<Byte[]> {
+public class ByteArrayValueHandler extends BaseValueHandler<byte[]> {
 
     @Override
-    protected void internalHandle(DataOutputStream buffer, final Byte[] value) throws Exception {
+    protected void internalHandle(DataOutputStream buffer, final byte[] value) throws Exception {
         buffer.writeInt(value.length);
-        for(Byte b : value) {
+        for(byte b : value) {
             buffer.writeByte(b);
         }
     }

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/StringValueHandler.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/StringValueHandler.java
@@ -4,15 +4,14 @@
 package de.bytefish.pgbulkinsert.pgsql.handlers;
 
 import java.io.DataOutputStream;
-import java.nio.charset.Charset;
+
+import de.bytefish.pgbulkinsert.util.StringUtils;
 
 public class StringValueHandler extends BaseValueHandler<String> {
-	
-	private Charset utf8Charset = Charset.forName("UTF-8");
 
     @Override
     protected void internalHandle(DataOutputStream buffer, final String value) throws Exception {
-        byte[] utf8Bytes = value.getBytes(utf8Charset);
+        byte[] utf8Bytes = StringUtils.getUtf8Bytes(value);
 
         buffer.writeInt(utf8Bytes.length);
         buffer.write(utf8Bytes);

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/StringValueHandler.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/StringValueHandler.java
@@ -3,15 +3,16 @@
 
 package de.bytefish.pgbulkinsert.pgsql.handlers;
 
-import de.bytefish.pgbulkinsert.util.StringUtils;
-
 import java.io.DataOutputStream;
+import java.nio.charset.Charset;
 
 public class StringValueHandler extends BaseValueHandler<String> {
+	
+	private Charset utf8Charset = Charset.forName("UTF-8");
 
     @Override
     protected void internalHandle(DataOutputStream buffer, final String value) throws Exception {
-        byte[] utf8Bytes = StringUtils.getUtf8Bytes(value);
+        byte[] utf8Bytes = value.getBytes(utf8Charset);
 
         buffer.writeInt(utf8Bytes.length);
         buffer.write(utf8Bytes);

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/processor/handler/BulkWriteHandler.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/processor/handler/BulkWriteHandler.java
@@ -3,28 +3,29 @@
 
 package de.bytefish.pgbulkinsert.pgsql.processor.handler;
 
-import de.bytefish.pgbulkinsert.IPgBulkInsert;
-import de.bytefish.pgbulkinsert.functional.Func1;
-import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import org.postgresql.PGConnection;
-
 import java.sql.Connection;
 import java.util.List;
+import java.util.function.Supplier;
+
+import org.postgresql.PGConnection;
+
+import de.bytefish.pgbulkinsert.IPgBulkInsert;
+import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
 
 public class BulkWriteHandler<TEntity> implements IBulkWriteHandler<TEntity> {
 
     private final IPgBulkInsert<TEntity> client;
 
-    private final Func1<Connection> connectionFactory;
+    private final Supplier<Connection> connectionFactory;
 
-    public BulkWriteHandler(IPgBulkInsert<TEntity> client, Func1<Connection> connectionFactory) {
+    public BulkWriteHandler(IPgBulkInsert<TEntity> client, Supplier<Connection> connectionFactory) {
         this.client = client;
         this.connectionFactory = connectionFactory;
     }
 
     public void write(List<TEntity> entities) throws Exception {
         // Obtain a new Connection and execute it in a try with resources block, so it gets closed properly:
-        try(Connection connection = connectionFactory.invoke()) {
+        try(Connection connection = connectionFactory.get()) {
             // Now get the underlying PGConnection for the COPY API wrapping:
             final PGConnection pgConnection = PostgreSqlUtils.getPGConnection(connection);
             // And finally save all entities by using the COPY API:

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/util/StringUtils.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/util/StringUtils.java
@@ -3,7 +3,11 @@
 
 package de.bytefish.pgbulkinsert.util;
 
+import java.nio.charset.Charset;
+
 public class StringUtils {
+	
+	private static Charset utf8Charset = Charset.forName("UTF-8");
 
     private StringUtils() {}
 
@@ -12,11 +16,7 @@ public class StringUtils {
     }
 
     public static byte[] getUtf8Bytes(String value) {
-        try {
-            return value.getBytes("UTF-8");
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        return value.getBytes(utf8Charset);
     }
 
 }

--- a/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/pgsql/handlers/NumericArrayTypesTest.java
+++ b/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/pgsql/handlers/NumericArrayTypesTest.java
@@ -3,17 +3,7 @@
 
 package de.bytefish.pgbulkinsert.pgsql.handlers;
 
-import de.bytefish.pgbulkinsert.PgBulkInsert;
-import de.bytefish.pgbulkinsert.functional.Func1;
-import de.bytefish.pgbulkinsert.functional.Func2;
-import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
-import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.net.UnknownHostException;
 import java.sql.Array;
 import java.sql.ResultSet;
@@ -22,6 +12,15 @@ import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import de.bytefish.pgbulkinsert.PgBulkInsert;
+import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
+import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
+import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 
 public class NumericArrayTypesTest extends TransactionalTestBase {
 
@@ -147,7 +146,7 @@ public class NumericArrayTypesTest extends TransactionalTestBase {
         testArrayInternal("col_integer_array", entity, entity.integerArray, BigDecimal::intValue);
     }
 
-    private <T> void testArrayInternal(String columnLabel, ArrayEntity entity, List<T> samples, Func2<BigDecimal, T> converter) throws SQLException, UnknownHostException {
+    private <T> void testArrayInternal(String columnLabel, ArrayEntity entity, List<T> samples, Function<BigDecimal, T> converter) throws SQLException, UnknownHostException {
 
         List<ArrayEntity> entities = Collections.singletonList(entity);
 
@@ -164,7 +163,7 @@ public class NumericArrayTypesTest extends TransactionalTestBase {
 
             for (int i=0; i<samples.size(); i++) {
 
-                T element = converter.invoke(v[i]);
+                T element = converter.apply(v[i]);
 
                 Assert.assertEquals(samples.get(i), element);
             }

--- a/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/pgsql/processor/BulkProcessorTest.java
+++ b/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/pgsql/processor/BulkProcessorTest.java
@@ -5,7 +5,6 @@ package de.bytefish.pgbulkinsert.pgsql.processor;
 
 import de.bytefish.pgbulkinsert.IPgBulkInsert;
 import de.bytefish.pgbulkinsert.PgBulkInsert;
-import de.bytefish.pgbulkinsert.functional.Func1;
 import de.bytefish.pgbulkinsert.mapping.PersonMapping;
 import de.bytefish.pgbulkinsert.model.Person;
 import de.bytefish.pgbulkinsert.pgsql.processor.handler.IBulkWriteHandler;
@@ -22,6 +21,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 public class BulkProcessorTest extends TransactionalTestBase {
 
@@ -34,15 +34,15 @@ public class BulkProcessorTest extends TransactionalTestBase {
     class CustomBulkWriteHandler<TEntity> implements IBulkWriteHandler<TEntity> {
 
         private final IPgBulkInsert<TEntity> client;
-        private final Func1<Connection> connectionFactory;
+        private final Supplier<Connection> connectionFactory;
 
-        public CustomBulkWriteHandler(IPgBulkInsert<TEntity> client, Func1<Connection> connectionFactory) {
+        public CustomBulkWriteHandler(IPgBulkInsert<TEntity> client, Supplier<Connection> connectionFactory) {
             this.client = client;
             this.connectionFactory = connectionFactory;
         }
 
         public void write(List<TEntity> entities) throws Exception {
-            Connection connection = connectionFactory.invoke();
+            Connection connection = connectionFactory.get();
 
             client.saveAll(PostgreSqlUtils.getPGConnection(connection), entities.stream());
         }
@@ -57,7 +57,7 @@ public class BulkProcessorTest extends TransactionalTestBase {
         // Create the BulkInserter to be wrapped:
         IPgBulkInsert<Person> personBulkInserter = CreateBulkInserter();
         // Create the ConnectionFactory:
-        Func1<Connection> connectionFactory = () -> connection;
+        Supplier<Connection> connectionFactory = () -> connection;
         // Create the BulkHandler:
         IBulkWriteHandler<Person> bulkWriteHandler = new CustomBulkWriteHandler<>(personBulkInserter, connectionFactory);
         // Create the BulkProcessor:
@@ -78,7 +78,7 @@ public class BulkProcessorTest extends TransactionalTestBase {
         // Create the BulkInserter to be wrapped:
         IPgBulkInsert<Person> personBulkInserter = CreateBulkInserter();
         // Create the ConnectionFactory:
-        Func1<Connection> connectionFactory = () -> connection;
+        Supplier<Connection> connectionFactory = () -> connection;
         // Create the BulkHandler:
         IBulkWriteHandler<Person> bulkWriteHandler = new CustomBulkWriteHandler<>(personBulkInserter, connectionFactory);
         // Create the BulkProcessor:
@@ -101,7 +101,7 @@ public class BulkProcessorTest extends TransactionalTestBase {
         // Create the BulkInserter to be wrapped:
         IPgBulkInsert<Person> personBulkInserter = CreateBulkInserter();
         // Create the ConnectionFactory:
-        Func1<Connection> connectionFactory = () -> connection;
+        Supplier<Connection> connectionFactory = () -> connection;
         // Create the BulkHandler:
         IBulkWriteHandler<Person> bulkWriteHandler = new CustomBulkWriteHandler<>(personBulkInserter, connectionFactory);
         // Create the BulkProcessor:


### PR DESCRIPTION
For optimization it would be good to add/refactor ByteArrayValueHandler for primitive byte arrays