### PR TITLE
Add mapping for primitive types

### DIFF
--- a/PgBulkInsert/pom.xml
+++ b/PgBulkInsert/pom.xml
@@ -38,6 +38,9 @@
         <developer>
             <name>Irmo Manie</name>
         </developer>
+        <developer>
+            <name>Mariusz Kowalczyk</name>
+        </developer>
     </developers>
 
     <!-- Build Information -->

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/function/ToBooleanFunction.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/function/ToBooleanFunction.java
@@ -1,0 +1,13 @@
+package de.bytefish.pgbulkinsert.function;
+
+@FunctionalInterface
+public interface ToBooleanFunction<T> {
+
+	/**
+	 * Applies this function to the given argument.
+	 *
+	 * @param value the function argument
+	 * @return the function result
+	 */
+	boolean applyAsBoolean(T value);
+}

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/function/ToFloatFunction.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/function/ToFloatFunction.java
@@ -1,0 +1,13 @@
+package de.bytefish.pgbulkinsert.function;
+
+@FunctionalInterface
+public interface ToFloatFunction<T> {
+
+	/**
+	 * Applies this function to the given argument.
+	 *
+	 * @param value the function argument
+	 * @return the function result
+	 */
+	float applyAsFloat(T value);
+}

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/mapping/AbstractMapping.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/mapping/AbstractMapping.java
@@ -3,6 +3,8 @@
 
 package de.bytefish.pgbulkinsert.mapping;
 
+import de.bytefish.pgbulkinsert.function.ToBooleanFunction;
+import de.bytefish.pgbulkinsert.function.ToFloatFunction;
 import de.bytefish.pgbulkinsert.model.ColumnDefinition;
 import de.bytefish.pgbulkinsert.model.TableDefinition;
 import de.bytefish.pgbulkinsert.pgsql.PgBinaryWriter;
@@ -22,6 +24,9 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 
 public abstract class AbstractMapping<TEntity> {
@@ -66,18 +71,41 @@ public abstract class AbstractMapping<TEntity> {
     protected void mapBoolean(String columnName, Function<TEntity, Boolean> propertyGetter) {
         map(columnName, DataType.Boolean, propertyGetter);
     }
+    
+    protected void mapBoolean(String columnName, ToBooleanFunction<TEntity> propertyGetter) {
+        addColumn(columnName, (binaryWriter, entity) -> {
+            binaryWriter.writeBoolean(propertyGetter.applyAsBoolean(entity));
+        });
+    }
 
     protected void mapByte(String columnName, Function<TEntity, Number> propertyGetter) {
         map(columnName, DataType.Char, propertyGetter);
     }
+    
+    protected void mapByte(String columnName, ToIntFunction<TEntity> propertyGetter) {
+        addColumn(columnName, (binaryWriter, entity) -> {
+            binaryWriter.writeByte(propertyGetter.applyAsInt(entity));
+        });
+    }
 
     protected void mapShort(String columnName, Function<TEntity, Number> propertyGetter) {
-
         map(columnName, DataType.Int2, propertyGetter);
+    }
+    
+    protected void mapShort(String columnName, ToIntFunction<TEntity> propertyGetter) {
+        addColumn(columnName, (binaryWriter, entity) -> {
+            binaryWriter.writeShort(propertyGetter.applyAsInt(entity));
+        });
     }
 
     protected void mapInteger(String columnName, Function<TEntity, Number> propertyGetter) {
         map(columnName, DataType.Int4, propertyGetter);
+    }
+    
+    protected void mapInteger(String columnName, ToIntFunction<TEntity> propertyGetter) {
+        addColumn(columnName, (binaryWriter, entity) -> {
+            binaryWriter.writeInt(propertyGetter.applyAsInt(entity));
+        });
     }
 
     protected void mapNumeric(String columnName, Function<TEntity, Number> propertyGetter) {
@@ -87,13 +115,31 @@ public abstract class AbstractMapping<TEntity> {
     protected void mapLong(String columnName, Function<TEntity, Number> propertyGetter) {
         map(columnName, DataType.Int8, propertyGetter);
     }
+    
+    protected void mapLong(String columnName, ToLongFunction<TEntity> propertyGetter) {
+        addColumn(columnName, (binaryWriter, entity) -> {
+            binaryWriter.writeLong(propertyGetter.applyAsLong(entity));
+        });
+    }
 
     protected void mapFloat(String columnName, Function<TEntity, Number> propertyGetter) {
         map(columnName, DataType.SinglePrecision, propertyGetter);
     }
+    
+    protected void mapFloat(String columnName, ToFloatFunction<TEntity> propertyGetter) {
+        addColumn(columnName, (binaryWriter, entity) -> {
+            binaryWriter.writeFloat(propertyGetter.applyAsFloat(entity));
+        });
+    }
 
     protected void mapDouble(String columnName, Function<TEntity, Number> propertyGetter) {
         map(columnName, DataType.DoublePrecision, propertyGetter);
+    }
+    
+    protected void mapDouble(String columnName, ToDoubleFunction<TEntity> propertyGetter) {
+        addColumn(columnName, (binaryWriter, entity) -> {
+            binaryWriter.writeDouble(propertyGetter.applyAsDouble(entity));
+        });
     }
 
     protected void mapDate(String columnName, Function<TEntity, LocalDate> propertyGetter) {

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/PgBinaryWriter.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/PgBinaryWriter.java
@@ -30,21 +30,6 @@ public class PgBinaryWriter implements AutoCloseable {
         writeHeader();
     }
 
-    private void writeHeader() {
-        try {
-
-            // 11 bytes required header
-            buffer.writeBytes("PGCOPY\n\377\r\n\0");
-            // 32 bit integer indicating no OID
-            buffer.writeInt(0);
-            // 32 bit header extension area length
-            buffer.writeInt(0);
-
-        } catch(Exception e) {
-            throw new BinaryWriteFailedException(e);
-        }
-    }
-
     public void startRow(int numColumns) {
         try {
             buffer.writeShort(numColumns);
@@ -56,6 +41,116 @@ public class PgBinaryWriter implements AutoCloseable {
     public <TTargetType> void write(final IValueHandler<TTargetType> handler, final TTargetType value) {
         handler.handle(buffer, value);
     }
+    
+    /**
+     * Writes primitive boolean to the output stream
+     *  
+     * @param value value to write
+     * 
+     */
+	public void writeBoolean(boolean value) {
+		try {
+			buffer.writeInt(1);
+			if (value) {
+				buffer.writeByte(1);
+			} else {
+				buffer.writeByte(0);
+			}
+		} catch (Exception e) {
+			throw new BinaryWriteFailedException(e);
+		}
+	}
+
+	
+    /**
+     * Writes primitive byte to the output stream
+     *  
+     * @param value value to write
+     * 
+     */
+	public void writeByte(int value) {
+		try {
+			buffer.writeInt(1);
+			buffer.writeByte(value);
+		} catch (Exception e) {
+			throw new BinaryWriteFailedException(e);
+		}
+	}
+
+    /**
+     * Writes primitive short to the output stream
+     *  
+     * @param value value to write
+     * 
+     */
+	public void writeShort(int value) {
+		try {
+			buffer.writeInt(2);
+			buffer.writeShort(value);
+		} catch (Exception e) {
+			throw new BinaryWriteFailedException(e);
+		}
+	}
+
+    /**
+     * Writes primitive integer to the output stream
+     *  
+     * @param value value to write
+     * 
+     */
+	public void writeInt(int value) {
+		try {
+			buffer.writeInt(4);
+			buffer.writeInt(value);
+		} catch (Exception e) {
+			throw new BinaryWriteFailedException(e);
+		}
+	}
+
+    /**
+     * Writes primitive long to the output stream
+     *  
+     * @param value value to write
+     * 
+     */
+	public void writeLong(long value) {
+		try {
+			buffer.writeInt(8);
+			buffer.writeLong(value);
+		} catch (Exception e) {
+			throw new BinaryWriteFailedException(e);
+		}
+	}
+	
+    /**
+     * Writes primitive float to the output stream
+     *  
+     * @param value value to write
+     * 
+     */
+	public void writeFloat(float value) {
+		try {
+	        buffer.writeInt(4);
+	        buffer.writeFloat(value);
+		} catch (Exception e) {
+			throw new BinaryWriteFailedException(e);
+		}
+	}
+
+    /**
+     * Writes primitive double to the output stream
+     *  
+     * @param value value to write
+     * 
+     */
+	public void writeDouble(double value) {
+		try {
+			buffer.writeInt(8);
+			buffer.writeDouble(value);
+		} catch (Exception e) {
+			throw new BinaryWriteFailedException(e);
+		}
+	}
 
     @Override
     public void close() {
@@ -64,6 +159,21 @@ public class PgBinaryWriter implements AutoCloseable {
 
             buffer.flush();
             buffer.close();
+        } catch(Exception e) {
+            throw new BinaryWriteFailedException(e);
+        }
+    }
+    
+    private void writeHeader() {
+        try {
+
+            // 11 bytes required header
+            buffer.writeBytes("PGCOPY\n\377\r\n\0");
+            // 32 bit integer indicating no OID
+            buffer.writeInt(0);
+            // 32 bit header extension area length
+            buffer.writeInt(0);
+
         } catch(Exception e) {
             throw new BinaryWriteFailedException(e);
         }

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/ValueHandlerProvider.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/ValueHandlerProvider.java
@@ -7,16 +7,16 @@ import de.bytefish.pgbulkinsert.exceptions.ValueHandlerAlreadyRegisteredExceptio
 import de.bytefish.pgbulkinsert.exceptions.ValueHandlerNotRegisteredException;
 import de.bytefish.pgbulkinsert.pgsql.constants.DataType;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 public class ValueHandlerProvider implements IValueHandlerProvider {
 
-    private Map<DataType, ValueHandler> valueHandlers;
+    private final Map<DataType, IValueHandler> valueHandlers;
 
     public ValueHandlerProvider() {
-        valueHandlers = new HashMap<>();
+        valueHandlers = new EnumMap<>(DataType.class);
 
         add(DataType.Boolean, new BooleanValueHandler());
         add(DataType.Char, new ByteValueHandler<>());
@@ -58,10 +58,13 @@ public class ValueHandlerProvider implements IValueHandlerProvider {
 
     @Override
     public <TTargetType> IValueHandler<TTargetType> resolve(DataType dataType) {
-        if(!valueHandlers.containsKey(dataType)) {
+    	
+    	@SuppressWarnings("unchecked")
+		IValueHandler<TTargetType> handler = valueHandlers.get(dataType);
+        if(handler == null) {
             throw new ValueHandlerNotRegisteredException(String.format("DataType '%s' has not been registered", dataType));
         }
-        return (IValueHandler<TTargetType>) valueHandlers.get(dataType);
+        return handler;
     }
 
 

--- a/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/pgsql/handlers/PgBulkInsertPrimitivesTest.java
+++ b/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/pgsql/handlers/PgBulkInsertPrimitivesTest.java
@@ -1,0 +1,229 @@
+package de.bytefish.pgbulkinsert.pgsql.handlers;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import de.bytefish.pgbulkinsert.PgBulkInsert;
+import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
+import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
+import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
+
+public class PgBulkInsertPrimitivesTest extends TransactionalTestBase {
+
+	private class SampleEntity {
+
+		public int col_integer;
+		public float col_float;
+		public double col_double;
+		public long col_long;
+		public short col_short;
+		public byte[] col_bytearray;
+		public boolean col_boolean;
+		
+		
+		public int getCol_integer() {
+			return col_integer;
+		}
+		public float getCol_float() {
+			return col_float;
+		}
+		public double getCol_double() {
+			return col_double;
+		}
+		public long getCol_long() {
+			return col_long;
+		}
+		public short getCol_short() {
+			return col_short;
+		}
+		public byte[] getCol_bytearray() {
+			return col_bytearray;
+		}
+		public boolean isCol_boolean() {
+			return col_boolean;
+		}
+
+	}
+	
+    @Override
+    protected void onSetUpInTransaction() throws Exception {
+        createTable();
+    }
+
+    @Override
+    protected void onSetUpBeforeTransaction() throws Exception {
+
+    }
+    
+    private class SampleEntityMapping extends AbstractMapping<SampleEntity> {
+
+        public SampleEntityMapping() {
+            super(schema, "unit_test");
+
+            mapBoolean("col_boolean", SampleEntity::isCol_boolean);
+            mapInteger("col_integer", SampleEntity::getCol_integer);
+            mapShort("col_smallint", SampleEntity::getCol_short);
+            mapLong("col_long", SampleEntity::getCol_long);
+            mapByteArray("col_bytea", SampleEntity::getCol_bytearray);
+            mapFloat("col_real", SampleEntity::getCol_float);
+            mapDouble("col_double", SampleEntity::getCol_double);
+        }
+    }
+    
+    @Test
+    public void saveAll_boolean_Test() throws SQLException {
+
+        // This list will be inserted.
+        List<SampleEntity> entities = new ArrayList<>();
+
+        // Create the Entity to insert:
+        SampleEntity entity = new SampleEntity();
+        entity.col_boolean = true;
+
+        entities.add(entity);
+
+        PgBulkInsert<SampleEntity> pgBulkInsert = new PgBulkInsert<>(new SampleEntityMapping());
+
+        pgBulkInsert.saveAll(PostgreSqlUtils.getPGConnection(connection), entities.stream());
+
+        ResultSet rs = getAll();
+
+        while (rs.next()) {
+            boolean v = rs.getBoolean("col_boolean");
+
+            Assert.assertEquals(true, v);
+        }
+    }
+    
+    @Test
+    public void saveAll_Short_Test() throws SQLException {
+
+        // This list will be inserted.
+        List<SampleEntity> entities = new ArrayList<>();
+
+        // Create the Entity to insert:
+        SampleEntity entity = new SampleEntity();
+        entity.col_short = 1;
+
+        entities.add(entity);
+
+        PgBulkInsert<SampleEntity> pgBulkInsert = new PgBulkInsert<>(new SampleEntityMapping());
+
+        pgBulkInsert.saveAll(PostgreSqlUtils.getPGConnection(connection), entities.stream());
+
+        ResultSet rs = getAll();
+
+        while (rs.next()) {
+            short v = rs.getShort("col_smallint");
+
+            Assert.assertEquals(1, v);
+        }
+    }
+    
+    @Test
+    public void saveAll_Integer_Test() throws SQLException {
+
+        // This list will be inserted.
+        List<SampleEntity> entities = new ArrayList<>();
+
+        // Create the Entity to insert:
+        SampleEntity entity = new SampleEntity();
+        entity.col_integer = 1;
+
+        entities.add(entity);
+
+        PgBulkInsert<SampleEntity> pgBulkInsert = new PgBulkInsert<>(new SampleEntityMapping());
+
+        pgBulkInsert.saveAll(PostgreSqlUtils.getPGConnection(connection), entities.stream());
+
+        ResultSet rs = getAll();
+
+        while (rs.next()) {
+            int v = rs.getInt("col_integer");
+
+            Assert.assertEquals(1, v);
+        }
+    }
+    
+    @Test
+    public void saveAll_Single_Precision_Test() throws SQLException {
+
+        // This list will be inserted.
+        List<SampleEntity> entities = new ArrayList<>();
+
+        // Create the Entity to insert:
+        SampleEntity entity = new SampleEntity();
+        entity.col_float = 2.0001f;
+
+        entities.add(entity);
+
+        PgBulkInsert<SampleEntity> pgBulkInsert = new PgBulkInsert<>(new SampleEntityMapping());
+
+        pgBulkInsert.saveAll(PostgreSqlUtils.getPGConnection(connection), entities.stream());
+
+        ResultSet rs = getAll();
+
+        while (rs.next()) {
+            float v = rs.getFloat("col_real");
+
+            Assert.assertEquals(2.0001, v, 1e-6);
+        }
+    }
+    
+    @Test
+    public void saveAll_Double_Precision_Test() throws SQLException {
+
+        // This list will be inserted.
+        List<SampleEntity> entities = new ArrayList<>();
+
+        // Create the Entity to insert:
+        SampleEntity entity = new SampleEntity();
+        entity.col_double = 2.0001;
+
+        entities.add(entity);
+
+        PgBulkInsert<SampleEntity> pgBulkInsert = new PgBulkInsert<>(new SampleEntityMapping());
+
+        pgBulkInsert.saveAll(PostgreSqlUtils.getPGConnection(connection), entities.stream());
+
+        ResultSet rs = getAll();
+
+        while (rs.next()) {
+            double v = rs.getDouble("col_double");
+
+            Assert.assertEquals(2.0001, v, 1e-10);
+        }
+    }
+    
+    private boolean createTable() throws SQLException {
+        String sqlStatement = String.format("CREATE TABLE %s.unit_test\n", schema) +
+                "            (\n" +
+                "                col_smallint smallint,\n" +
+                "                col_integer integer,\n" +
+                "                col_long bigint,\n" +
+                "                col_real real,\n" +
+                "                col_double double precision,\n" +
+                "                col_bytea bytea,\n" +
+                "                col_boolean boolean\n" +
+                "            );";
+
+        Statement statement = connection.createStatement();
+
+        return statement.execute(sqlStatement);
+    }
+    
+    private ResultSet getAll() throws SQLException {
+        String sqlStatement = String.format("SELECT * FROM %s.unit_test", schema);
+
+        Statement statement = connection.createStatement();
+
+        return statement.executeQuery(sqlStatement);
+    }
+
+}


### PR DESCRIPTION
In performant applications boxing/unboxing primitive  numeric values can be overkill.