### PR TITLE
Added support for postgis data types (do not merge yet)

### DIFF
--- a/PgBulkInsert/pom.xml
+++ b/PgBulkInsert/pom.xml
@@ -155,6 +155,12 @@
         </dependency>
 
         <dependency>
+            <groupId>mil.nga.sf</groupId>
+            <artifactId>sf-wkb</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/mapping/AbstractMapping.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/mapping/AbstractMapping.java
@@ -16,6 +16,7 @@ import de.bytefish.pgbulkinsert.pgsql.handlers.IValueHandlerProvider;
 import de.bytefish.pgbulkinsert.pgsql.handlers.ValueHandlerProvider;
 import de.bytefish.pgbulkinsert.pgsql.model.geometric.*;
 import de.bytefish.pgbulkinsert.pgsql.model.network.MacAddress;
+import mil.nga.sf.Geometry;
 
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -262,10 +263,14 @@ public abstract class AbstractMapping<TEntity> {
         mapCollection(columnName, DataType.Inet6, propertyGetter);
     }
 
+    protected void mapPostgis(String columnName, Function<TEntity, Geometry> propertyGetter) {
+        map(columnName, DataType.Postgis, propertyGetter);
+    }
+
     private void addColumn(String columnName, BiConsumer<PgBinaryWriter, TEntity> action) {
         columns.add(new ColumnDefinition(columnName, action));
     }
-
+    
     public List<ColumnDefinition<TEntity>> getColumns() {
         return columns;
     }

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/constants/DataType.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/constants/DataType.java
@@ -52,6 +52,7 @@ public enum DataType {
     Bit,
     VarBit,
     Record,
-    Numeric
+    Numeric,
+    Postgis,
 
 }

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/PostgisValueHandler.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/PostgisValueHandler.java
@@ -1,0 +1,22 @@
+package de.bytefish.pgbulkinsert.pgsql.handlers;
+
+import mil.nga.sf.Geometry;
+import mil.nga.sf.util.ByteWriter;
+import mil.nga.sf.wkb.GeometryWriter;
+
+import java.io.DataOutputStream;
+import java.nio.ByteOrder;
+
+public class PostgisValueHandler extends BaseValueHandler<Geometry> {
+
+    @Override
+    protected void internalHandle(DataOutputStream buffer, Geometry value) throws Exception {
+        ByteWriter writer = new ByteWriter();
+        writer.setByteOrder(ByteOrder.LITTLE_ENDIAN);
+        GeometryWriter.writeGeometry(writer, value);
+        byte[] wkb = writer.getBytes();
+        buffer.writeInt(wkb.length);
+        buffer.write(wkb);
+    }
+
+}

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/ValueHandlerProvider.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/ValueHandlerProvider.java
@@ -44,6 +44,7 @@ public class ValueHandlerProvider implements IValueHandlerProvider {
         add(DataType.Polygon, new PolygonValueHandler());
         add(DataType.Circle, new CircleValueHandler());
         add(DataType.MacAddress, new MacAddressValueHandler());
+        add(DataType.Postgis, new PostgisValueHandler());
     }
 
     public <TTargetType> ValueHandlerProvider add(DataType targetType, IValueHandler<TTargetType> valueHandler) {

--- a/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/pgsql/handlers/PostgisExtensionTest.java
+++ b/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/pgsql/handlers/PostgisExtensionTest.java
@@ -1,0 +1,96 @@
+package de.bytefish.pgbulkinsert.pgsql.handlers;
+
+import de.bytefish.pgbulkinsert.PgBulkInsert;
+import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
+import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
+import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
+import mil.nga.sf.Geometry;
+import mil.nga.sf.Point;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PostgisExtensionTest extends TransactionalTestBase {
+
+    private class PostgisEntity {
+
+        private Geometry col_postgis;
+
+        public Geometry getCol_postgis() {
+            return col_postgis;
+        }
+
+        public void setCol_postgis(Geometry col_postgis) {
+            this.col_postgis = col_postgis;
+        }
+    }
+
+    @Override
+    protected void onSetUpInTransaction() throws Exception {
+        createTable();
+    }
+
+    @Override
+    protected void onSetUpBeforeTransaction() throws Exception {
+
+    }
+
+    private class PostgisEntityMapping extends AbstractMapping<PostgisExtensionTest.PostgisEntity> {
+
+        public PostgisEntityMapping() {
+            super(schema, "postgis_table");
+            mapPostgis("col_postgis", PostgisExtensionTest.PostgisEntity::getCol_postgis);
+        }
+    }
+
+    private boolean createTable() throws SQLException {
+        String sqlStatement = String.format("CREATE TABLE %s.postgis_table(\n", schema) +
+                "                col_postgis Geometry(POINT) \n" +
+                "            );";
+
+        Statement statement = connection.createStatement();
+
+        return statement.execute(sqlStatement);
+    }
+
+    @Test
+    @Ignore("This Test Requires the postgis extension to be enabled.")
+    public void saveAll_Postgis_Test() throws SQLException {
+
+        // This list will be inserted.
+        List<PostgisExtensionTest.PostgisEntity> entities = new ArrayList<>();
+
+        // Create the Map to Store:
+        Geometry postgisData = new Point(1, 1);
+
+        // Create the Entity to insert:
+        PostgisExtensionTest.PostgisEntity entity = new PostgisExtensionTest.PostgisEntity();
+        entity.setCol_postgis(postgisData);
+
+        entities.add(entity);
+
+        PgBulkInsert<PostgisExtensionTest.PostgisEntity> bulkInsert = new PgBulkInsert<>(new PostgisExtensionTest.PostgisEntityMapping());
+
+        bulkInsert.saveAll(PostgreSqlUtils.getPGConnection(connection), entities.stream());
+
+        ResultSet rs = getAll();
+
+        while (rs.next()) {
+            String wkt = rs.getString("geom");
+            Assert.assertEquals("POINT(1 1)", wkt);
+        }
+    }
+
+    private ResultSet getAll() throws SQLException {
+        String sqlStatement = String.format("SELECT ST_AsText(col_postgis) AS geom FROM %s.postgis_table", schema);
+        Statement statement = connection.createStatement();
+        return statement.executeQuery(sqlStatement);
+    }
+
+}


### PR DESCRIPTION
First attempt at addressing issue #35. This version adds a dependency to sf-wkb that allows to generically read and write wkb features. The main issue with this version is that sf-wkb uses a `ByteWriter` that wraps its own `ByteArrayOutputStream` to produce a byte array, i.e., copying byte arrays probably leads to some garbage.

https://github.com/ngageoint/simple-features-wkb-java