### PR TITLE
Add utilities to partition streams

### DIFF
--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/streams/BatchSpliterator.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/streams/BatchSpliterator.java
@@ -1,0 +1,51 @@
+package de.bytefish.pgbulkinsert.streams;
+
+import java.util.Comparator;
+import java.util.Spliterator;
+
+import static java.util.Spliterators.spliterator;
+
+public abstract class BatchSpliterator <T> implements Spliterator<T> {
+
+    private final int batchSize;
+
+    private final int characteristics;
+
+    public BatchSpliterator(int batchSize, int characteristics) {
+        this.batchSize = batchSize;
+        this.characteristics = characteristics | SUBSIZED;
+    }
+
+    @Override
+    public Spliterator<T> trySplit() {
+        final HoldingConsumer consumer = new HoldingConsumer();
+        if (!tryAdvance(consumer)) {
+            return null;
+        }
+        final Object[] batch = new Object[batchSize];
+        int j = 0;
+        do {
+            batch[j] = consumer.getValue();
+        } while (++j < batchSize && tryAdvance(consumer));
+        return spliterator(batch, 0, j, characteristics() | SIZED);
+    }
+
+    @Override
+    public Comparator<? super T> getComparator() {
+        if (hasCharacteristics(SORTED)) {
+            return null;
+        }
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public long estimateSize() {
+        return Long.MAX_VALUE;
+    }
+
+    @Override
+    public int characteristics() {
+        return characteristics;
+    }
+
+}

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/streams/HoldingConsumer.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/streams/HoldingConsumer.java
@@ -1,0 +1,18 @@
+package de.bytefish.pgbulkinsert.streams;
+
+import java.util.function.Consumer;
+
+public class HoldingConsumer implements Consumer {
+
+    private Object value;
+
+    @Override
+    public void accept(Object value) {
+        this.value = value;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+}

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/streams/PartitioningSpliterator.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/streams/PartitioningSpliterator.java
@@ -1,0 +1,36 @@
+package de.bytefish.pgbulkinsert.streams;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
+public class PartitioningSpliterator<T> extends BatchSpliterator<Collection<T>> {
+
+    private final Spliterator<T> spliterator;
+    private final int partitionSize;
+
+    public PartitioningSpliterator(Spliterator<T> spliterator, int partitionSize, int batchSize) {
+        super(batchSize, ORDERED | DISTINCT | NONNULL | IMMUTABLE);
+        assert partitionSize > 0;
+        this.spliterator = spliterator;
+        this.partitionSize = partitionSize;
+    }
+
+    @Override
+    public boolean tryAdvance(Consumer<? super Collection<T>> consumer) {
+        final HoldingConsumer holder = new HoldingConsumer();
+        if (!spliterator.tryAdvance(holder)) {
+            return false;
+        }
+        final List<T> partition = new ArrayList<>();
+        int j = 0;
+        do {
+            partition.add((T) holder.getValue());
+        } while (++j < partitionSize && spliterator.tryAdvance(holder));
+        consumer.accept(partition);
+        return true;
+    }
+
+}

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/streams/StreamUtil.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/streams/StreamUtil.java
@@ -1,0 +1,15 @@
+package de.bytefish.pgbulkinsert.streams;
+
+import java.util.Collection;
+import java.util.Spliterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class StreamUtil {
+
+    public static <T> Stream<Collection<T>> partition(Stream<T> stream, int partitionSize, int batchSize) {
+        Spliterator<Collection<T>> spliterator = new PartitioningSpliterator<T>(stream.spliterator(), partitionSize, batchSize);
+        return StreamSupport.stream(spliterator, true);
+    }
+
+}

--- a/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/streams/PartitioningSpliteratorTest.java
+++ b/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/streams/PartitioningSpliteratorTest.java
@@ -1,0 +1,29 @@
+package de.bytefish.pgbulkinsert.streams;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class PartitioningSpliteratorTest {
+
+    @Test
+    public void partitioningSpliteratorTest() throws ExecutionException, InterruptedException {
+        int num = 100000;
+        int partitionSize = 10;
+        int batchSize = 10000;
+        Stream<Collection<Integer>> s = StreamUtil.partition(IntStream.range(0, num).mapToObj(i -> i), partitionSize, batchSize);
+        ForkJoinPool forkJoinPool = new ForkJoinPool(10);
+        long sum = forkJoinPool.submit(() -> s.map(p -> {
+            long count = p.stream().count();
+            Assert.assertTrue(count == partitionSize);
+            return count;
+        }).reduce((a, b) -> a + b)).get().get();
+        Assert.assertTrue(sum == num);
+    }
+
+}


### PR DESCRIPTION
This pull request introduces utilities to partition and consume streams in parallel. The `PartitioningSpliterator` is based on the `BatchSpliterator` introduced by [Marko Topolnik](https://www.airpair.com/java/posts/parallel-processing-of-io-based-data-with-java-streams).

@bytefish As [discussed](https://github.com/bchapuis/stream-util/issues/1
), do not hesitate to refactor the code according to your preferences. Also, I did not commited the `Main` class as it introduces a dependency to dbcp2.

```java
public class Main {

    static class PgBulkInsertConsumer<TEntity> implements Consumer<Collection<TEntity>> {

        private final PgBulkInsert<TEntity> bulkInsert;

        private final DataSource dataSource;

        public PgBulkInsertConsumer(PgBulkInsert<TEntity> bulkInsert, PoolingDataSource dataSource) {
            this.bulkInsert = bulkInsert;
            this.dataSource = dataSource;
        }

        @Override
        public void accept(Collection<TEntity> entities) {
            try (Connection connection = dataSource.getConnection()) {
                PGConnection pgConnection = connection.unwrap(PGConnection.class);
                bulkInsert.saveAll(pgConnection, entities);
            } catch (SQLException e) {
                e.printStackTrace();
            }
        }

    }

    static class IntegerMapping extends AbstractMapping<Integer> {

        public IntegerMapping() {
            super("public", "integers");
            mapInteger("i", Integer::intValue);
        }

    }

    public static void main(String[] args) throws ExecutionException, InterruptedException {
        int num = 10000000;
        int partitionSize = 1000;
        int batchSize = 10;

        // create table integers (i int);
        PoolingDataSource dataSource = dataSource("jdbc:postgresql://localhost:5432/osm?user=osm&password=osm");
        PgBulkInsert<Integer> bulkInsert = new PgBulkInsert<>(new IntegerMapping());

        ForkJoinPool forkJoinPool = new ForkJoinPool(10);
        forkJoinPool.submit(() ->  StreamUtil
                .partition(IntStream.range(0, num).mapToObj(i -> i).parallel(), partitionSize, batchSize)
                .forEach(new PgBulkInsertConsumer<Integer>(bulkInsert, dataSource))).get();
    }

    public static PoolingDataSource dataSource(String conn) {
        ConnectionFactory connectionFactory = new DriverManagerConnectionFactory(conn, null);
        PoolableConnectionFactory poolableConnectionFactory = new PoolableConnectionFactory(connectionFactory, null);
        ObjectPool<PoolableConnection> connectionPool = new GenericObjectPool<>(poolableConnectionFactory);
        poolableConnectionFactory.setPool(connectionPool);
        PoolingDataSource<PoolableConnection> dataSource = new PoolingDataSource<>(connectionPool);
        return dataSource;
    }

}
```
 

