### PR TITLE
Introduce a generic RowWriter for more extensible

### DIFF
--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/row/SimpleRow.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/row/SimpleRow.java
@@ -5,7 +5,7 @@ import de.bytefish.pgbulkinsert.pgsql.constants.DataType;
 import de.bytefish.pgbulkinsert.pgsql.constants.ObjectIdentifier;
 import de.bytefish.pgbulkinsert.pgsql.handlers.CollectionValueHandler;
 import de.bytefish.pgbulkinsert.pgsql.handlers.IValueHandler;
-import de.bytefish.pgbulkinsert.pgsql.handlers.ValueHandlerProvider;
+import de.bytefish.pgbulkinsert.pgsql.handlers.IValueHandlerProvider;
 import de.bytefish.pgbulkinsert.pgsql.model.geometric.*;
 import de.bytefish.pgbulkinsert.pgsql.model.network.MacAddress;
 
@@ -22,12 +22,12 @@ import java.util.function.Consumer;
 
 public class SimpleRow {
 
-    private final ValueHandlerProvider provider;
+    private final IValueHandlerProvider provider;
     private final Map<String, Integer> lookup;
     private final Map<Integer, Consumer<PgBinaryWriter>> actions;
 
     @SuppressWarnings("unchecked")
-    public SimpleRow(ValueHandlerProvider provider, Map<String, Integer> lookup) {
+    public SimpleRow(IValueHandlerProvider provider, Map<String, Integer> lookup) {
         this.provider = provider;
         this.lookup = lookup;
         this.actions = new HashMap<>();

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/row/SimpleRowWriter.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/row/SimpleRowWriter.java
@@ -1,6 +1,7 @@
 package de.bytefish.pgbulkinsert.row;
 
 import de.bytefish.pgbulkinsert.pgsql.PgBinaryWriter;
+import de.bytefish.pgbulkinsert.pgsql.handlers.IValueHandlerProvider;
 import de.bytefish.pgbulkinsert.pgsql.handlers.ValueHandlerProvider;
 import de.bytefish.pgbulkinsert.util.StringUtils;
 import org.postgresql.PGConnection;
@@ -53,19 +54,23 @@ public class SimpleRowWriter {
 
     private final Table table;
     private final PgBinaryWriter writer;
-    private final ValueHandlerProvider provider;
+    private final IValueHandlerProvider provider;
     private final Map<String, Integer> lookup;
 
-    public SimpleRowWriter(Table table) {
+    public SimpleRowWriter(Table table, IValueHandlerProvider valueHandlerProvider) {
         this.writer = new PgBinaryWriter();
         this.table = table;
-        this.provider = new ValueHandlerProvider();
+        this.provider = valueHandlerProvider;
 
         this.lookup = new HashMap<>();
 
         for (int ordinal = 0; ordinal < table.columns.length; ordinal++) {
             lookup.put(table.columns[ordinal], ordinal);
         }
+    }
+
+    public SimpleRowWriter(Table table) {
+        this(table, new ValueHandlerProvider());
     }
 
     public void open(PGConnection connection) throws SQLException  {

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/row/SimpleRowWriter.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/row/SimpleRowWriter.java
@@ -77,11 +77,15 @@ public class SimpleRowWriter {
         writer.open(new PGCopyOutputStream(connection, getCopyCommand(table), 1));
     }
 
+    protected SimpleRow createRow() {
+        return new SimpleRow(provider, lookup);
+    }
+
     public synchronized void startRow(Consumer<SimpleRow> consumer) {
 
         writer.startRow(table.columns.length);
 
-        SimpleRow row = new SimpleRow(provider, lookup);
+        SimpleRow row = createRow();
 
         consumer.accept(row);
 

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/row/SimpleRowWriter.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/row/SimpleRowWriter.java
@@ -1,107 +1,28 @@
+/*******************************************************************************
+ *  Copyright (c) 2019, 2020 lucendar.com.
+ *  All rights reserved.
+ *
+ *  Contributors:
+ *     KwanKin Yau (alphax@vip.163.com) - initial API and implementation
+ *******************************************************************************/
 package de.bytefish.pgbulkinsert.row;
 
-import de.bytefish.pgbulkinsert.pgsql.PgBinaryWriter;
 import de.bytefish.pgbulkinsert.pgsql.handlers.IValueHandlerProvider;
-import de.bytefish.pgbulkinsert.pgsql.handlers.ValueHandlerProvider;
-import de.bytefish.pgbulkinsert.util.StringUtils;
-import org.postgresql.PGConnection;
-import org.postgresql.copy.PGCopyOutputStream;
 
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
-public class SimpleRowWriter {
-
-    public static class Table {
-
-        private final String schema;
-        private final String table;
-        private final String[] columns;
-
-        public Table(String table, String... columns) {
-            this(null, table, columns);
-        }
-
-        public Table(String schema, String table, String... columns) {
-            this.schema = schema;
-            this.table = table;
-            this.columns = columns;
-        }
-
-        public String getSchema() {
-            return schema;
-        }
-
-        public String getTable() {
-            return table;
-        }
-
-        public String[] getColumns() {
-            return columns;
-        }
-
-        public String GetFullyQualifiedTableName() {
-            if (StringUtils.isNullOrWhiteSpace(schema)) {
-                return table;
-            }
-            return String.format("%1$s.%2$s", schema, table);
-        }
-    }
-
-    private final Table table;
-    private final PgBinaryWriter writer;
-    private final IValueHandlerProvider provider;
-    private final Map<String, Integer> lookup;
+public class SimpleRowWriter extends RowWriter<SimpleRow> {
 
     public SimpleRowWriter(Table table, IValueHandlerProvider valueHandlerProvider) {
-        this.writer = new PgBinaryWriter();
-        this.table = table;
-        this.provider = valueHandlerProvider;
-
-        this.lookup = new HashMap<>();
-
-        for (int ordinal = 0; ordinal < table.columns.length; ordinal++) {
-            lookup.put(table.columns[ordinal], ordinal);
-        }
+        super(table, valueHandlerProvider);
     }
 
     public SimpleRowWriter(Table table) {
-        this(table, new ValueHandlerProvider());
+        super(table);
     }
 
-    public void open(PGConnection connection) throws SQLException  {
-        writer.open(new PGCopyOutputStream(connection, getCopyCommand(table), 1));
-    }
-
-    protected SimpleRow createRow() {
+    @Override
+    protected SimpleRow createRow(IValueHandlerProvider provider, Map<String, Integer> lookup) {
         return new SimpleRow(provider, lookup);
-    }
-
-    public synchronized void startRow(Consumer<SimpleRow> consumer) {
-
-        writer.startRow(table.columns.length);
-
-        SimpleRow row = createRow();
-
-        consumer.accept(row);
-
-        row.writeRow(writer);
-    }
-
-    public void close() throws SQLException  {
-        writer.close();
-    }
-
-    private static String getCopyCommand(Table table) {
-        String commaSeparatedColumns = Arrays.stream(table.columns)
-                .collect(Collectors.joining(", "));
-
-        return String.format("COPY %1$s(%2$s) FROM STDIN BINARY",
-                table.GetFullyQualifiedTableName(),
-                commaSeparatedColumns);
     }
 }


### PR DESCRIPTION
My application use OffsetDateTime instead of ZonedDateTime for date time representation, when I look into the code, I found the PgBulkInsert cannot extended do easily for this propose. So I extracted a generic RowWriter from original SimpleRowWriter and add a constructor to accept customized IValueHandlerProvider to it, then someone can create an extended RowWriter/SimpleRow for thier uses.