### PR TITLE
Support read only attributes

### DIFF
--- a/PgBulkInsert/pgbulkinsert-bulkprocessor/src/test/java/de/bytefish/pgbulkinsert/test/bulkprocessor/BulkProcessorTest.java
+++ b/PgBulkInsert/pgbulkinsert-bulkprocessor/src/test/java/de/bytefish/pgbulkinsert/test/bulkprocessor/BulkProcessorTest.java
@@ -6,11 +6,11 @@ package de.bytefish.pgbulkinsert.test.bulkprocessor;
 import de.bytefish.pgbulkinsert.IPgBulkInsert;
 import de.bytefish.pgbulkinsert.PgBulkInsert;
 import de.bytefish.pgbulkinsert.bulkprocessor.BulkProcessor;
+import de.bytefish.pgbulkinsert.bulkprocessor.handler.IBulkWriteHandler;
 import de.bytefish.pgbulkinsert.test.mapping.PersonMapping;
 import de.bytefish.pgbulkinsert.test.model.Person;
-import de.bytefish.pgbulkinsert.bulkprocessor.handler.IBulkWriteHandler;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
 import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/integration/CustomValueHandlerIntegrationTest.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/integration/CustomValueHandlerIntegrationTest.java
@@ -8,8 +8,8 @@ import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
 import de.bytefish.pgbulkinsert.pgsql.handlers.BaseValueHandler;
 import de.bytefish.pgbulkinsert.pgsql.handlers.BigDecimalValueHandler;
 import de.bytefish.pgbulkinsert.pgsql.handlers.IValueHandler;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
 import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/integration/IntegrationTest.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/integration/IntegrationTest.java
@@ -6,8 +6,8 @@ package de.bytefish.pgbulkinsert.test.integration;
 import de.bytefish.pgbulkinsert.PgBulkInsert;
 import de.bytefish.pgbulkinsert.test.mapping.PersonMapping;
 import de.bytefish.pgbulkinsert.test.model.Person;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
 import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/integration/Issue23DuplicatesTest.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/integration/Issue23DuplicatesTest.java
@@ -5,8 +5,8 @@ package de.bytefish.pgbulkinsert.test.integration;
 
 import de.bytefish.pgbulkinsert.PgBulkInsert;
 import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
 import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/integration/Issue32NumericTest.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/integration/Issue32NumericTest.java
@@ -5,8 +5,8 @@ package de.bytefish.pgbulkinsert.test.integration;
 
 import de.bytefish.pgbulkinsert.PgBulkInsert;
 import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
 import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/ArrayTypesTest.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/ArrayTypesTest.java
@@ -5,8 +5,8 @@ package de.bytefish.pgbulkinsert.test.pgsql.handlers;
 
 import de.bytefish.pgbulkinsert.PgBulkInsert;
 import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
 import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/GeometricTypesTest.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/GeometricTypesTest.java
@@ -5,12 +5,24 @@ package de.bytefish.pgbulkinsert.test.pgsql.handlers;
 
 import de.bytefish.pgbulkinsert.PgBulkInsert;
 import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
-import de.bytefish.pgbulkinsert.pgsql.model.geometric.*;
+import de.bytefish.pgbulkinsert.pgsql.model.geometric.Box;
+import de.bytefish.pgbulkinsert.pgsql.model.geometric.Circle;
+import de.bytefish.pgbulkinsert.pgsql.model.geometric.Line;
+import de.bytefish.pgbulkinsert.pgsql.model.geometric.LineSegment;
+import de.bytefish.pgbulkinsert.pgsql.model.geometric.Path;
+import de.bytefish.pgbulkinsert.pgsql.model.geometric.Point;
+import de.bytefish.pgbulkinsert.pgsql.model.geometric.Polygon;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
 import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 import org.junit.Assert;
 import org.junit.Test;
-import org.postgresql.geometric.*;
+import org.postgresql.geometric.PGbox;
+import org.postgresql.geometric.PGcircle;
+import org.postgresql.geometric.PGline;
+import org.postgresql.geometric.PGlseg;
+import org.postgresql.geometric.PGpath;
+import org.postgresql.geometric.PGpoint;
+import org.postgresql.geometric.PGpolygon;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;

--- a/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/HstoreExtensionTest.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/HstoreExtensionTest.java
@@ -5,8 +5,8 @@ package de.bytefish.pgbulkinsert.test.pgsql.handlers;
 
 import de.bytefish.pgbulkinsert.PgBulkInsert;
 import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
 import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -14,7 +14,10 @@ import org.junit.Test;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class HstoreExtensionTest extends TransactionalTestBase {
 

--- a/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/NetworkTypesTest.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/NetworkTypesTest.java
@@ -5,13 +5,11 @@ package de.bytefish.pgbulkinsert.test.pgsql.handlers;
 
 import de.bytefish.pgbulkinsert.PgBulkInsert;
 import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
-import de.bytefish.pgbulkinsert.pgsql.model.geometric.*;
 import de.bytefish.pgbulkinsert.pgsql.model.network.MacAddress;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
 import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 import org.junit.Assert;
 import org.junit.Test;
-import org.postgresql.geometric.*;
 import org.postgresql.util.PGobject;
 
 import java.sql.ResultSet;

--- a/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/NumericArrayTypesTest.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/NumericArrayTypesTest.java
@@ -3,6 +3,13 @@
 
 package de.bytefish.pgbulkinsert.test.pgsql.handlers;
 
+import de.bytefish.pgbulkinsert.PgBulkInsert;
+import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
+import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.math.BigDecimal;
 import java.net.UnknownHostException;
 import java.sql.Array;
@@ -13,14 +20,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
-
-import org.junit.Assert;
-import org.junit.Test;
-
-import de.bytefish.pgbulkinsert.PgBulkInsert;
-import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
-import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 
 public class NumericArrayTypesTest extends TransactionalTestBase {
 

--- a/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/PgBulkInsertPrimitivesTest.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/PgBulkInsertPrimitivesTest.java
@@ -1,18 +1,17 @@
 package de.bytefish.pgbulkinsert.test.pgsql.handlers;
 
+import de.bytefish.pgbulkinsert.PgBulkInsert;
+import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
+import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.junit.Assert;
-import org.junit.Test;
-
-import de.bytefish.pgbulkinsert.PgBulkInsert;
-import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
-import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 
 public class PgBulkInsertPrimitivesTest extends TransactionalTestBase {
 

--- a/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/PgBulkInsertTest.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/PgBulkInsertTest.java
@@ -5,8 +5,8 @@ package de.bytefish.pgbulkinsert.test.pgsql.handlers;
 
 import de.bytefish.pgbulkinsert.PgBulkInsert;
 import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
 import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -14,10 +14,17 @@ import java.math.BigDecimal;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.UnknownHostException;
-import java.sql.*;
+import java.sql.Array;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
 
 public class PgBulkInsertTest extends TransactionalTestBase {
 

--- a/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/RangeTypesTest.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/RangeTypesTest.java
@@ -5,14 +5,11 @@ package de.bytefish.pgbulkinsert.test.pgsql.handlers;
 
 import de.bytefish.pgbulkinsert.PgBulkInsert;
 import de.bytefish.pgbulkinsert.mapping.AbstractMapping;
-import de.bytefish.pgbulkinsert.pgsql.constants.DataType;
-import de.bytefish.pgbulkinsert.pgsql.model.geometric.*;
 import de.bytefish.pgbulkinsert.pgsql.model.range.Range;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
 import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 import org.junit.Assert;
 import org.junit.Test;
-import org.postgresql.geometric.*;
 import org.postgresql.util.PGobject;
 
 import java.sql.ResultSet;

--- a/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/utils/TransactionalTestBase.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/utils/TransactionalTestBase.java
@@ -1,7 +1,7 @@
 // Copyright (c) Philipp Wagner. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-package de.bytefish.pgbulkinsert.utils;
+package de.bytefish.pgbulkinsert.test.utils;
 
 import org.junit.After;
 import org.junit.Before;

--- a/PgBulkInsert/pgbulkinsert-jpa/pom.xml
+++ b/PgBulkInsert/pgbulkinsert-jpa/pom.xml
@@ -29,9 +29,15 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>2.2.6.RELEASE</version>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.12</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>de.bytefish.pgbulkinsert</groupId>

--- a/PgBulkInsert/pgbulkinsert-jpa/src/test/java/de/bytefish/pgbulkinsert/test/jpa/JpaMappingTests.java
+++ b/PgBulkInsert/pgbulkinsert-jpa/src/test/java/de/bytefish/pgbulkinsert/test/jpa/JpaMappingTests.java
@@ -6,18 +6,26 @@ package de.bytefish.pgbulkinsert.test.jpa;
 import de.bytefish.pgbulkinsert.PgBulkInsert;
 import de.bytefish.pgbulkinsert.jpa.JpaMapping;
 import de.bytefish.pgbulkinsert.pgsql.constants.DataType;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
 import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 import org.postgresql.PGConnection;
-import org.postgresql.util.PGobject;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class JpaMappingTests extends TransactionalTestBase {
 
@@ -39,6 +47,9 @@ public class JpaMappingTests extends TransactionalTestBase {
 
         @Column(name = "text_field")
         private String textField;
+
+        @Column(name = "read_only_text_field")
+        private String readOnlyTextField;
 
         @Enumerated(value = EnumType.STRING)
         @Column(name = "enum_string_field")
@@ -74,6 +85,10 @@ public class JpaMappingTests extends TransactionalTestBase {
 
         public void setTextField(String textField) {
             this.textField = textField;
+        }
+
+        public String getReadOnlyTextField() {
+            return readOnlyTextField;
         }
 
         public SampleEntityTypeEnum getTypeStringField() {
@@ -234,6 +249,7 @@ public class JpaMappingTests extends TransactionalTestBase {
                 "                id int8,\n" +
                 "                int_field int4,\n" +
                 "                text_field text,\n" +
+                "                read_only_text_field text,\n" +
                 "                enum_string_field text,\n" +
                 "                enum_smallint_field smallint,\n" +
                 "                enum_smallint_field_as_integer int4\n" +

--- a/PgBulkInsert/pgbulkinsert-rowwriter/src/test/java/de/bytefish/pgbulkinsert/test/row/NullTerminatingStringTest.java
+++ b/PgBulkInsert/pgbulkinsert-rowwriter/src/test/java/de/bytefish/pgbulkinsert/test/row/NullTerminatingStringTest.java
@@ -2,13 +2,12 @@ package de.bytefish.pgbulkinsert.test.row;
 
 
 import de.bytefish.pgbulkinsert.row.SimpleRowWriter;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
 import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 import org.postgresql.PGConnection;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 

--- a/PgBulkInsert/pgbulkinsert-rowwriter/src/test/java/de/bytefish/pgbulkinsert/test/row/SimpleRowWriterTest.java
+++ b/PgBulkInsert/pgbulkinsert-rowwriter/src/test/java/de/bytefish/pgbulkinsert/test/row/SimpleRowWriterTest.java
@@ -2,8 +2,8 @@ package de.bytefish.pgbulkinsert.test.row;
 
 import de.bytefish.pgbulkinsert.pgsql.model.range.Range;
 import de.bytefish.pgbulkinsert.row.SimpleRowWriter;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
 import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 import org.postgresql.PGConnection;

--- a/PgBulkInsert/pgbulkinsert-rowwriter/src/test/java/de/bytefish/pgbulkinsert/test/row/SimpleRowWriterWithQuotesTest.java
+++ b/PgBulkInsert/pgbulkinsert-rowwriter/src/test/java/de/bytefish/pgbulkinsert/test/row/SimpleRowWriterWithQuotesTest.java
@@ -1,8 +1,8 @@
 package de.bytefish.pgbulkinsert.test.row;
 
 import de.bytefish.pgbulkinsert.row.SimpleRowWriter;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
 import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
-import de.bytefish.pgbulkinsert.utils.TransactionalTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 import org.postgresql.PGConnection;


### PR DESCRIPTION
As described in issue #54 we also have read only attributes. This attempts to handle the issue. I have added org.reflect as dependency, as it allows a bit better reflection handling that the vanilla reflection instruments.

I have run and extended the tests against a local postgresql instance, as it appears to be designed by the `TransactionalTestBase`. 

I would recommend to have a look into [Testcontainers](https://github.com/testcontainers/testcontainers-java) that would ease the setup time for other contributors and would allow integration to services like Travis CI.