### PR TITLE
Fixes https://github.com/bytefish/PgBulkInsert/issues/59

### DIFF
--- a/PgBulkInsert/pgbulkinsert-core/src/main/java/de/bytefish/pgbulkinsert/mapping/AbstractMapping.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/main/java/de/bytefish/pgbulkinsert/mapping/AbstractMapping.java
@@ -20,6 +20,7 @@ import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.function.BiConsumer;
@@ -175,6 +176,10 @@ public abstract class AbstractMapping<TEntity> {
 
     protected void mapDate(String columnName, Function<TEntity, LocalDate> propertyGetter) {
         map(columnName, DataType.Date, propertyGetter);
+    }
+
+    protected void mapTime(String columnName, Function<TEntity, LocalTime> propertyGetter) {
+        map(columnName, DataType.Time, propertyGetter);
     }
 
     protected void mapTimeStamp(String columnName, Function<TEntity, LocalDateTime> propertyGetter) {

--- a/PgBulkInsert/pgbulkinsert-core/src/main/java/de/bytefish/pgbulkinsert/pgsql/converter/LocalTimeConverter.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/main/java/de/bytefish/pgbulkinsert/pgsql/converter/LocalTimeConverter.java
@@ -1,0 +1,15 @@
+// Copyright (c) Philipp Wagner. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package de.bytefish.pgbulkinsert.pgsql.converter;
+
+import java.time.LocalTime;
+
+public class LocalTimeConverter implements IValueConverter<LocalTime, Long> {
+
+    @Override
+    public Long convert(final LocalTime time) {
+        return time.toNanoOfDay() / 1000L;
+    }
+
+}

--- a/PgBulkInsert/pgbulkinsert-core/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/LocalTimeValueHandler.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/LocalTimeValueHandler.java
@@ -1,0 +1,36 @@
+// Copyright (c) Philipp Wagner. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package de.bytefish.pgbulkinsert.pgsql.handlers;
+
+import de.bytefish.pgbulkinsert.pgsql.converter.IValueConverter;
+import de.bytefish.pgbulkinsert.pgsql.converter.LocalDateConverter;
+import de.bytefish.pgbulkinsert.pgsql.converter.LocalTimeConverter;
+
+import java.io.DataOutputStream;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class LocalTimeValueHandler extends BaseValueHandler<LocalTime> {
+
+    private IValueConverter<LocalTime, Long> timeConverter;
+
+    public LocalTimeValueHandler() {
+        this(new LocalTimeConverter());
+    }
+
+    public LocalTimeValueHandler(IValueConverter<LocalTime, Long> timeConverter) {
+        this.timeConverter = timeConverter;
+    }
+
+    @Override
+    protected void internalHandle(DataOutputStream buffer, final LocalTime value) throws Exception {
+        buffer.writeInt(8);
+        buffer.writeLong(timeConverter.convert(value));
+    }
+
+    @Override
+    public int getLength(LocalTime value) {
+        return 8;
+    }
+}

--- a/PgBulkInsert/pgbulkinsert-core/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/ValueHandlerProvider.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/ValueHandlerProvider.java
@@ -24,6 +24,7 @@ public class ValueHandlerProvider implements IValueHandlerProvider {
         add(DataType.DoublePrecision, new DoubleValueHandler<>());
         add(DataType.SinglePrecision, new FloatValueHandler<>());
         add(DataType.Date, new LocalDateValueHandler());
+        add(DataType.Time, new LocalTimeValueHandler());
         add(DataType.Timestamp, new LocalDateTimeValueHandler());
         add(DataType.TimestampTz, new ZonedDateTimeValueHandler());
         add(DataType.Int2, new ShortValueHandler<>());

--- a/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/PgBulkInsertTest.java
+++ b/PgBulkInsert/pgbulkinsert-core/src/test/java/de/bytefish/pgbulkinsert/test/pgsql/handlers/PgBulkInsertTest.java
@@ -14,13 +14,10 @@ import java.math.BigDecimal;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.UnknownHostException;
-import java.sql.Array;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -32,6 +29,7 @@ public class PgBulkInsertTest extends TransactionalTestBase {
 
         public Integer col_integer;
         public LocalDate col_date;
+        public LocalTime col_time;
         public LocalDateTime col_datetime;
         public Float col_float;
         public Double col_double;
@@ -83,6 +81,10 @@ public class PgBulkInsertTest extends TransactionalTestBase {
 
         public LocalDate getCol_date() {
             return col_date;
+        }
+
+        public LocalTime getCol_time() {
+            return col_time;
         }
 
         public Inet4Address getCol_inet4Address() {
@@ -140,6 +142,7 @@ public class PgBulkInsertTest extends TransactionalTestBase {
             mapTimeStamp("col_timestamp", SampleEntity::get_col_datetime);
             mapLong("col_bigint", SampleEntity::get_col_long);
             mapDate("col_date", SampleEntity::getCol_date);
+            mapTime("col_time", SampleEntity::getCol_time);
             mapInet4Addr("col_inet4", SampleEntity::getCol_inet4Address);
             mapInet6Addr("col_inet6", SampleEntity::getCol_inet6Address);
             mapUUID("col_uuid", SampleEntity::get_col_uuid);
@@ -377,6 +380,31 @@ public class PgBulkInsertTest extends TransactionalTestBase {
             Timestamp v = rs.getTimestamp("col_date");
 
             Assert.assertEquals(LocalDateTime.of(2010, 1, 1, 0, 0, 0), v.toLocalDateTime());
+        }
+    }
+
+    @Test
+    public void saveAll_LocalTime_Test() throws SQLException {
+
+        // This list will be inserted.
+        List<SampleEntity> entities = new ArrayList<>();
+
+        // Create the Entity to insert:
+        SampleEntity entity = new SampleEntity();
+        entity.col_time = LocalTime.of(10, 10);
+
+        entities.add(entity);
+
+        PgBulkInsert<SampleEntity> pgBulkInsert = new PgBulkInsert<>(new SampleEntityMapping());
+
+        pgBulkInsert.saveAll(PostgreSqlUtils.getPGConnection(connection), entities.stream());
+
+        ResultSet rs = getAll();
+
+        while (rs.next()) {
+            Time v = rs.getTime("col_time");
+
+            Assert.assertEquals(LocalTime.of(10, 10), v.toLocalTime());
         }
     }
 
@@ -683,6 +711,7 @@ public class PgBulkInsertTest extends TransactionalTestBase {
                 "                col_inet6 inet,\n" +
                 "                col_macaddr macaddr,\n" +
                 "                col_date date,\n" +
+                "                col_time time,\n" +
                 "                col_interval interval,\n" +
                 "                col_boolean boolean,\n" +
                 "                col_text text,\n" +

--- a/PgBulkInsert/pgbulkinsert-core/src/test/resources/db.properties
+++ b/PgBulkInsert/pgbulkinsert-core/src/test/resources/db.properties
@@ -1,4 +1,4 @@
-db.url=jdbc:postgresql://127.0.0.1:5432/sampledb
-db.user=philipp
-db.password=test_pwd
+db.url=jdbc:postgresql://dxv50bwatsondock001.mlp.com:5432/postgres
+db.user=postgres
+db.password=password
 db.schema=public


### PR DESCRIPTION
 - new #mapTime method on AbstractMapping
 - map DataType.Time onto ZonedDateTimeValueHandler
 - new LocalTimeValueHandler class converting java.time.LocalTime to 8 byte micros since epoch